### PR TITLE
📚 Nuisance create workflow docstring

### DIFF
--- a/docs/user/_sources/nuisance.txt
+++ b/docs/user/_sources/nuisance.txt
@@ -27,7 +27,7 @@ tCompCor
 """"""""
 As showed by Lund and Hanson (2001), voxel time courses with a relatively high temporal standard deviation were dominated by physiological noise. Behzadi et al. (2007) proposed an unsupervised method to assess the temporal standard deviation and then used princial components analysis to reduce the data dimensionality.
 
-Global Signal Regression 
+Global Signal Regression
 """"""""""""""""""""""""
 Global signal, the average signal across all voxels in the brain, is assumed to reflect a combination of resting-state fluctuations, physiological noise (e.g. respiratory and cardiac noise), and other noise signals with non-neural origin. Global signal regression (GSR) is a preprocessing technique for removing the spontaneous BOLD fluctuations common to the whole brain using a general linear model (GLM). Although GSR can potentially change functional connectivity distributions and result in increased negative correlations (Murphy et al., 2009; Saad et al., 2012; Weissenbacher et al., 2009), this technique has been shown to facilitate the detection of localized neuronal signals and improve the specificity of functional connectivity analysis (Fox et al., 2005; Fox et al., 2009). Thus, GSR remains a common and useful processing technique in some situations.
 
@@ -61,7 +61,7 @@ C-PAC runs volume realignment on all functional images during functional preproc
 
 Regression of Motion Parameters
 """""""""""""""""""""""""""""""
-Another approach to motion correction is to regress out the effects of motion when running statistical analysis. This is done by calculating motion parameters and including them in your General Linear Model (Fox et al., 2005; Weissenbacher et al., 2009). 
+Another approach to motion correction is to regress out the effects of motion when running statistical analysis. This is done by calculating motion parameters and including them in your General Linear Model (Fox et al., 2005; Weissenbacher et al., 2009).
 
 By default, C-PAC will calculate and output the motion parameters used during volume realignment. You can optionally enable the calculation of additional motion parameters, including Framewise Displacement (FD) and DVARS (as described below and in Power et al., 2011).
 
@@ -90,7 +90,7 @@ Temporal Filtering
 ^^^^^^^^^^^^^^^^^^
 The overall goal of temporal filtering is to increase the signal-to-noise ratio. Due to the relatively poor temporal resolution of fMRI, time series data contain little high-frequency noise. They do, however, often contain very slow frequency fluctuations that may be unrelated to the signal of interest. Slow changes in magnetic field strength may be responsible for part of the low-frequency signal observed in fMRI time series (Smith et al., 1999). Other factors contributing to noise in a time series are cardiac and respiratory effects, which will often show up as noise around ~0.15 and ~0.34 Hz, respectively (Wager et al., 2007).  The temporal filtering method implemented by C-PAC is relatively simple. You specify a lower and upper bound for a band-pass filter, which then removes any information in frequencies outside the specified frequency band.
 
-Recent work has revealed a portion of the low-frequency signal (0.01 to 0.1 Hz) to be the result of slow oscillations intrinsic to brain activity (Gee et al., 2011; Zuo et al., 2010; Schroeder and Lakatos, 2009). Utilizing measures such as Amplitude of Low Frequency Fluctuations (ALFF) and fractional ALFF, the power of these oscillations has been shown to differ both across subjects (Zang et al., 2007) and between conditions (Yan et al., 2009). Resting functional connectivity has been shown to be most prominent at these frequency bands (Cordes et al., 2001), and as such these fluctuations are commonly used to measure functional connectivity in the resting brain (Gee et al., 2010). 
+Recent work has revealed a portion of the low-frequency signal (0.01 to 0.1 Hz) to be the result of slow oscillations intrinsic to brain activity (Gee et al., 2011; Zuo et al., 2010; Schroeder and Lakatos, 2009). Utilizing measures such as Amplitude of Low Frequency Fluctuations (ALFF) and fractional ALFF, the power of these oscillations has been shown to differ both across subjects (Zang et al., 2007) and between conditions (Yan et al., 2009). Resting functional connectivity has been shown to be most prominent at these frequency bands (Cordes et al., 2001), and as such these fluctuations are commonly used to measure functional connectivity in the resting brain (Gee et al., 2010).
 
 As these low-frequency oscillations are likely of interest to researchers, it is important to take this knowledge into account when deciding on what temporal filtering settings to use. As a general rule, it is safe to filter frequencies below 0.0083 Hz (Ashby, 2011).
 
@@ -110,7 +110,7 @@ Configuring Nuisance Signal Regression Options
 
 .. figure:: /_images/nuisance.png
 
-#. **Run Nuisance Signal Correction - [Off, On, On/Off]:** Covary out various sources of noise. 
+#. **Run Nuisance Signal Correction - [Off, On, On/Off]:** Covary out various sources of noise.
 
 #. **Lateral Ventricles Mask (Standard Space) - [path, None]:** A binary mask of the lateral ventricles. If choosing None, no lateral ventricles mask will be applied.
 
@@ -133,7 +133,7 @@ The following box contains the full specification for regressors:
   aCompCor:
       summary:
           filter: 'cosine', Principal components are estimated after using a discrete cosine filter with 128s cut-off,
-              Leave filter field blank, if selected aCompcor method is 'DetrendPC'          
+              Leave filter field blank, if selected aCompcor method is 'DetrendPC'
           method: 'PC', aCompCor will always extract the principal components
               from tissues signal,
           components: number of components to retain,
@@ -158,16 +158,16 @@ The following box contains the full specification for regressors:
           regressor, default to False,
       include_delayed_squared: True | False, whether or not to include a
           squared one-frame delay regressor, default to False,
-  
+
   tCompCor:
       summary:
           filter: 'cosine', Principal components are estimated after using a discrete cosine filter with 128s cut-off,
-              Leave filter field blank, if selected aCompcor method is 'DetrendPC'          
+              Leave filter field blank, if selected aCompcor method is 'DetrendPC'
           method: 'PC', tCompCor will always extract the principal components from
               BOLD signal,
           components: number of components to retain,
-      
-      degree: 
+
+      degree:
           polynomial degree up to which will be removed from timeseries before generating the mask.
           Default is 1.
 
@@ -176,65 +176,65 @@ The following box contains the full specification for regressors:
           floating point number followed by SD (ex. 1.5SD) = mean + a multiple of the SD,
           floating point number followed by PCT (ex. 2PCT) = percentile from the top (ex is top 2%),
 
-      erode_mask: True | False, whether or not the eroded mask should be applied to calculate tCompCor. 
-          Choosing True will apply fMRIPrep-style eroded mask, which will be shrunk by 30 m. 
+      erode_mask: True | False, whether or not the eroded mask should be applied to calculate tCompCor.
+          Choosing True will apply fMRIPrep-style eroded mask, which will be shrunk by 30 m.
           Default is False.
 
       by_slice: True | False, whether or not the threshold criterion should be applied
           by slice or across the entire volume, makes most sense for thresholds
           using SD or PCT,
 
-      erode_mask: True | False, whether or not the eroded mask should be applied to calculate tCompCor. 
-          Choosing True will erode the mask by one voxel. 
+      erode_mask: True | False, whether or not the eroded mask should be applied to calculate tCompCor.
+          Choosing True will erode the mask by one voxel.
           Default is False.
 
-      erode_mask_mm: True | False, whether or not the eroded mask should be applied to calculate tCompCor. 
+      erode_mask_mm: True | False, whether or not the eroded mask should be applied to calculate tCompCor.
           Choosing True will erode the mask by custom proportion or mm. If choosing true, please also set brain_use_erosion: true; seg_csf_use_erosion: true.
-          and set custom options in brain_mask_erosion_prop and brain_mask_erosion_mm. 
+          and set custom options in brain_mask_erosion_prop and brain_mask_erosion_mm.
           Default is False.
 
       include_delayed: True | False,
       include_squared: True | False,
       include_delayed_squared: True | False,
-  
+
   WhiteMatter:
       summary:
           method: 'PC', 'Mean', 'NormMean' or 'DetrendNormMean',
           components: number of components to retain, if PC,
-      
+
       extraction_resolution: None | floating point value (same as for aCompCor),
       erode_mask: True | False (same as for aCompCor),
       include_delayed: True | False (same as for aCompCor),
       include_squared: True | False (same as for aCompCor),
       include_delayed_squared: True | False (same as for aCompCor),
-  
+
   CerebrospinalFluid:
       summary:
           method: 'PC', 'Mean', 'NormMean' or 'DetrendNormMean',
           components: number of components to retain, if PC,
-      
+
       extraction_resolution: None | floating point value (same as for aCompCor),
       erode_mask: True | False (same as for aCompCor),
       include_delayed: True | False (same as for aCompCor),
       include_squared: True | False (same as for aCompCor),
       include_delayed_squared: True | False (same as for aCompCor),
-  
+
   GreyMatter:
       summary:
           method: 'PC', 'Mean', 'NormMean' or 'DetrendNormMean',
           components: number of components to retain, if PC,
-      
+
       extraction_resolution: None | floating point value (same as for aCompCor),
       erode_mask: True | False (same as for aCompCor),
       include_delayed: True | False (same as for aCompCor),
       include_squared: True | False (same as for aCompCor),
       include_delayed_squared: True | False (same as for aCompCor),
-  
+
   GlobalSignal:
       summary:
           method: 'PC', 'Mean', 'NormMean' or 'DetrendNormMean',
           components: number of components to retain, if PC,
-      
+
       include_delayed: True | False (same as for aCompCor),
       include_squared: True | False (same as for aCompCor),
       include_delayed_squared: True | False (same as for aCompCor),
@@ -245,113 +245,45 @@ The following box contains the full specification for regressors:
         one regressor per voxel,
     convolve: perform the convolution operation of the given
         regressor with the timeseries,
-  
+
   Motion: None or dictionary with values:
       include_delayed: True | False (same as for aCompCor),
       include_squared: True | False (same as for aCompCor),
       include_delayed_squared: True | False (same as for aCompCor),
-  
+
   Censor:
       method: 'Kill', 'Zero', 'Interpolate' or 'SpikeRegression',
 
       thresholds: list of dictionary, with values
           type: 'FD_J', 'FD_P', 'DVARS',
           value: threshold value to be applied to metric
-      
+
       number_of_previous_trs_to_censor: integer, number of previous
           TRs to censor (remove or regress, if spike regression)
 
       number_of_subsequent_trs_to_censor: integer, number of
           subsequent TRs to censor (remove or regress, if spike
           regression)
-  
+
   PolyOrt:
       degree: integer, polynomial degree up to which will be removed,
           e.g. 2 means constant + linear + quadratic, practically
           that is probably, the most that will be need especially
           if band pass filtering
-  
+
   Bandpass:
       bottom_frequency: floating point value, frequency in hertz of
           the highpass part of the pass band, frequencies below this
           will be removed,
-          
+
       top_frequency: floating point value, frequency in hertz of the
           lowpass part of the pass band, frequencies above this
           will be removed
-  
+
 
 The box below contains an example of what these parameters might look like when defined in the YAML.
 
-.. code-block:: yaml
-
-    runNuisance : [1]
-    lateral_ventricles_mask : /usr/share/fsl/5.0/data/atlases/HarvardOxford/HarvardOxford-lateral-ventricles-thr25-2mm.nii.gz
-    
-    Regressors :
-
-      - Motion:
-          include_delayed: True
-
-        aCompCor:
-          summary:
-            method: DetrendPC
-            components: 5
-          tissues:
-            - WhiteMatter
-            - CerebrospinalFluid
-          extraction_resolution: 2
-
-        tCompCor:
-          summary:
-            filter: cosine
-            method: PC
-            components: 5
-          threshold: 1.5SD
-          by_slice: False
-          extraction_resolution: 2
-
-        CerebrospinalFluid:
-          summary: Mean
-          extraction_resolution: 2
-          erode_mask: true
-          
-        GlobalSignal:
-          summary: Mean
-
-        Custom:
-          - file: custom_signal.nii.gz
-            convolve: true
-
-        PolyOrt: 2
-
-        Censor:
-          method: Interpolate
-          thresholds:
-            - type: FD_J
-              value: 0.3
-            - type: DVARS
-              value: 0.5
-          number_of_previous_trs_to_censor: 0
-          number_of_subsequent_trs_to_censor: 0
-
-      - Motion:  # Empty motion to include just the 6 motion parameters
-      
-        aCompCor:
-          summary:
-            method: PC
-            components: 5
-          tissues:
-            - WhiteMatter
-            - CerebrospinalFluid
-          extraction_resolution: 2
-
-        CerebrospinalFluid:
-          summary: Mean
-          extraction_resolution: 2
-          erode_mask: true
-
-        PolyOrt: 2
+.. program-output:: python /build/docs/user/_sources/nuisance_regressors_docstring.py
 
 Translating from old C-PAC configuration
 """"""""""""""""""""""""""""""""""""""""
@@ -427,7 +359,7 @@ In order to provide flexibility for the nuisance regression strategies, we chang
 An example of nuisance regressors
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The following box contains an example of a TSV file generated by C-PAC with the regressors used on nuisance regression. 
+The following box contains an example of a TSV file generated by C-PAC with the regressors used on nuisance regression.
 
 .. code-block:: text
 
@@ -540,8 +472,8 @@ Weissenbacher, A., Kasess, C., Gerstl, F., Lanzenberger, R., Moser, E., Windisch
 
 Windischberger, C., Langenberger, H., Sycha, T., Tschernko, E.M., Fuchsjager-Mayerl, G., Schmetterer, L., Moser, E., 2002. `On the origin of respiratory artifacts in BOLD-EPI of the human brain <http://www.ncbi.nlm.nih.gov/pubmed/12467863>`_. Magn. Reson. Imaging 20, 575–582.
 
-Yan, C., Liu, D., He, Y., Zou, Q., Zhu, C., Zuo, X., Long, X., et al. (2009). `Spontaneous brain activity in the default mode network is sensitive to different resting-state conditions with limited cognitive load <http://www.plosone.org/article/info:doi/10.1371/journal.pone.0005743>`_. PLoS ONE, 4(5), e5743. 
+Yan, C., Liu, D., He, Y., Zou, Q., Zhu, C., Zuo, X., Long, X., et al. (2009). `Spontaneous brain activity in the default mode network is sensitive to different resting-state conditions with limited cognitive load <http://www.plosone.org/article/info:doi/10.1371/journal.pone.0005743>`_. PLoS ONE, 4(5), e5743.
 
-Zang, Y.-F., He, Y., Zhu, C.-Z., Cao, Q.-J., Sui, M.-Q., Liang, M., Tian, L.-X., et al. (2007). `Altered baseline brain activity in children with ADHD revealed by resting-state functional MRI <http://nlpr-web.ia.ac.cn/2007papers/gjkw/gk38.pdf>`_. Brain & development, 29(2), 83–91. 
+Zang, Y.-F., He, Y., Zhu, C.-Z., Cao, Q.-J., Sui, M.-Q., Liang, M., Tian, L.-X., et al. (2007). `Altered baseline brain activity in children with ADHD revealed by resting-state functional MRI <http://nlpr-web.ia.ac.cn/2007papers/gjkw/gk38.pdf>`_. Brain & development, 29(2), 83–91.
 
 Zuo, X.-N., Di Martino, A., Kelly, C., Shehzad, Z. E., Gee, D. G., Klein, D. F., Castellanos, F. X., et al. (2010). `The oscillating brain: complex and reliable <http://www.ncbi.nlm.nih.gov/pmc/articles/PMC2856476/>`_. Neuroimage, 49(2), 1432–1445.

--- a/docs/user/_sources/nuisance.txt
+++ b/docs/user/_sources/nuisance.txt
@@ -295,9 +295,9 @@ In order to provide flexibility for the nuisance regression strategies, we chang
 | .. code-block:: yaml | .. code-block:: yaml                                                                                                                           |
 |                      |                                                                                                                                                |
 |     compcor: 1       |     aCompCor:                                                                                                                                  |
-|                      |       summary:
-|                      |         filter:                                                                                                                                  |
-|                      |         method: DetrendPC                                                                                                                             |
+|                      |       summary:                                                                                                                                 |
+|                      |         filter:                                                                                                                                |
+|                      |         method: DetrendPC                                                                                                                      |
 |                      |         components: 5                                                                                                                          |
 |                      |       tissues:                                                                                                                                 |
 |                      |         - WhiteMatter                                                                                                                          |

--- a/docs/user/_sources/nuisance.txt
+++ b/docs/user/_sources/nuisance.txt
@@ -128,162 +128,79 @@ The following key/value pairs must be defined in your :doc:`pipeline configurati
 
 The following box contains the full specification for regressors:
 
-.. code-block:: none
-
-  aCompCor:
-      summary:
-          filter: 'cosine', Principal components are estimated after using a discrete cosine filter with 128s cut-off,
-              Leave filter field blank, if selected aCompcor method is 'DetrendPC'
-          method: 'PC', aCompCor will always extract the principal components
-              from tissues signal,
-          components: number of components to retain,
-
-      tissues: list of tissues to extract regressors.
-          Valid values are: 'WhiteMatter', 'CerebrospinalFluid',
-
-      extraction_resolution: None | floating point value indicating isotropic
-          resolution (ex. 2 for 2mm x 2mm x 2mm that data should be extracted at,
-          the corresponding tissue mask will be resampled to this resolution. The
-          functional data will also be resampled to this resolution, and the
-          extraction will occur at this new resolution. The goal is to avoid
-          contamination from undesired tissue components when extracting nuisance
-          regressors,
-
-      erode_mask: True | False, whether or not the mask should be eroded to
-          further avoid a mask overlapping with a different tissue class,
-
-      include_delayed: True | False, whether or not to include a one-frame
-          delay regressor, default to False,
-      include_squared: True | False, whether or not to include a squared
-          regressor, default to False,
-      include_delayed_squared: True | False, whether or not to include a
-          squared one-frame delay regressor, default to False,
-
-  tCompCor:
-      summary:
-          filter: 'cosine', Principal components are estimated after using a discrete cosine filter with 128s cut-off,
-              Leave filter field blank, if selected aCompcor method is 'DetrendPC'
-          method: 'PC', tCompCor will always extract the principal components from
-              BOLD signal,
-          components: number of components to retain,
-
-      degree:
-          polynomial degree up to which will be removed from timeseries before generating the mask.
-          Default is 1.
-
-      threshold:
-          floating point number = cutoff as raw variance value,
-          floating point number followed by SD (ex. 1.5SD) = mean + a multiple of the SD,
-          floating point number followed by PCT (ex. 2PCT) = percentile from the top (ex is top 2%),
-
-      erode_mask: True | False, whether or not the eroded mask should be applied to calculate tCompCor.
-          Choosing True will apply fMRIPrep-style eroded mask, which will be shrunk by 30 m.
-          Default is False.
-
-      by_slice: True | False, whether or not the threshold criterion should be applied
-          by slice or across the entire volume, makes most sense for thresholds
-          using SD or PCT,
-
-      erode_mask: True | False, whether or not the eroded mask should be applied to calculate tCompCor.
-          Choosing True will erode the mask by one voxel.
-          Default is False.
-
-      erode_mask_mm: True | False, whether or not the eroded mask should be applied to calculate tCompCor.
-          Choosing True will erode the mask by custom proportion or mm. If choosing true, please also set brain_use_erosion: true; seg_csf_use_erosion: true.
-          and set custom options in brain_mask_erosion_prop and brain_mask_erosion_mm.
-          Default is False.
-
-      include_delayed: True | False,
-      include_squared: True | False,
-      include_delayed_squared: True | False,
-
-  WhiteMatter:
-      summary:
-          method: 'PC', 'Mean', 'NormMean' or 'DetrendNormMean',
-          components: number of components to retain, if PC,
-
-      extraction_resolution: None | floating point value (same as for aCompCor),
-      erode_mask: True | False (same as for aCompCor),
-      include_delayed: True | False (same as for aCompCor),
-      include_squared: True | False (same as for aCompCor),
-      include_delayed_squared: True | False (same as for aCompCor),
-
-  CerebrospinalFluid:
-      summary:
-          method: 'PC', 'Mean', 'NormMean' or 'DetrendNormMean',
-          components: number of components to retain, if PC,
-
-      extraction_resolution: None | floating point value (same as for aCompCor),
-      erode_mask: True | False (same as for aCompCor),
-      include_delayed: True | False (same as for aCompCor),
-      include_squared: True | False (same as for aCompCor),
-      include_delayed_squared: True | False (same as for aCompCor),
-
-  GreyMatter:
-      summary:
-          method: 'PC', 'Mean', 'NormMean' or 'DetrendNormMean',
-          components: number of components to retain, if PC,
-
-      extraction_resolution: None | floating point value (same as for aCompCor),
-      erode_mask: True | False (same as for aCompCor),
-      include_delayed: True | False (same as for aCompCor),
-      include_squared: True | False (same as for aCompCor),
-      include_delayed_squared: True | False (same as for aCompCor),
-
-  GlobalSignal:
-      summary:
-          method: 'PC', 'Mean', 'NormMean' or 'DetrendNormMean',
-          components: number of components to retain, if PC,
-
-      include_delayed: True | False (same as for aCompCor),
-      include_squared: True | False (same as for aCompCor),
-      include_delayed_squared: True | False (same as for aCompCor),
-
-  Custom: list of dictionaries, containing:
-    file: file containing the regressors. It can be a CSV file,
-        with one regressor per column, or a Nifti image, with
-        one regressor per voxel,
-    convolve: perform the convolution operation of the given
-        regressor with the timeseries,
-
-  Motion: None or dictionary with values:
-      include_delayed: True | False (same as for aCompCor),
-      include_squared: True | False (same as for aCompCor),
-      include_delayed_squared: True | False (same as for aCompCor),
-
-  Censor:
-      method: 'Kill', 'Zero', 'Interpolate' or 'SpikeRegression',
-
-      thresholds: list of dictionary, with values
-          type: 'FD_J', 'FD_P', 'DVARS',
-          value: threshold value to be applied to metric
-
-      number_of_previous_trs_to_censor: integer, number of previous
-          TRs to censor (remove or regress, if spike regression)
-
-      number_of_subsequent_trs_to_censor: integer, number of
-          subsequent TRs to censor (remove or regress, if spike
-          regression)
-
-  PolyOrt:
-      degree: integer, polynomial degree up to which will be removed,
-          e.g. 2 means constant + linear + quadratic, practically
-          that is probably, the most that will be need especially
-          if band pass filtering
-
-  Bandpass:
-      bottom_frequency: floating point value, frequency in hertz of
-          the highpass part of the pass band, frequencies below this
-          will be removed,
-
-      top_frequency: floating point value, frequency in hertz of the
-          lowpass part of the pass band, frequencies above this
-          will be removed
-
+.. program-output:: python /build/docs/user/_sources/nuisance_regressors_docstring.py
 
 The box below contains an example of what these parameters might look like when defined in the YAML.
 
-.. program-output:: python /build/docs/user/_sources/nuisance_regressors_docstring.py
+.. code-block:: yaml
+
+    runNuisance : [1]
+    lateral_ventricles_mask : /usr/share/fsl/5.0/data/atlases/HarvardOxford/HarvardOxford-lateral-ventricles-thr25-2mm.nii.gz
+
+    Regressors :
+
+      - Motion:
+          include_delayed: True
+
+        aCompCor:
+          summary:
+            method: DetrendPC
+            components: 5
+          tissues:
+            - WhiteMatter
+            - CerebrospinalFluid
+          extraction_resolution: 2
+
+        tCompCor:
+          summary:
+            filter: cosine
+            method: PC
+            components: 5
+          threshold: 1.5SD
+          by_slice: False
+          extraction_resolution: 2
+
+        CerebrospinalFluid:
+          summary: Mean
+          extraction_resolution: 2
+          erode_mask: true
+
+        GlobalSignal:
+          summary: Mean
+
+        Custom:
+          - file: custom_signal.nii.gz
+            convolve: true
+
+        PolyOrt: 2
+
+        Censor:
+          method: Interpolate
+          thresholds:
+            - type: FD_J
+              value: 0.3
+            - type: DVARS
+              value: 0.5
+          number_of_previous_trs_to_censor: 0
+          number_of_subsequent_trs_to_censor: 0
+
+      - Motion:  # Empty motion to include just the 6 motion parameters
+
+        aCompCor:
+          summary:
+            method: PC
+            components: 5
+          tissues:
+            - WhiteMatter
+            - CerebrospinalFluid
+          extraction_resolution: 2
+
+        CerebrospinalFluid:
+          summary: Mean
+          extraction_resolution: 2
+          erode_mask: true
+
+        PolyOrt: 2
 
 Translating from old C-PAC configuration
 """"""""""""""""""""""""""""""""""""""""

--- a/docs/user/_sources/nuisance_regressors_docstring.py
+++ b/docs/user/_sources/nuisance_regressors_docstring.py
@@ -1,0 +1,17 @@
+from CPAC import nuisance
+
+nstring = nuisance.create_nuisance_workflow.__doc__[
+    nuisance.create_nuisance_workflow.__doc__.find(
+        "selector = "
+    ) + len("selector = ") + 1:nuisance.create_nuisance_workflow.__doc__.find(
+        "Workflow Outputs"
+    )
+].rstrip()[:-1].lstrip('\n')
+
+print('\n'.join([
+    '{',
+    '\n'.join([
+        n[nstring.find('aCompCor')-4:] for n in nstring.split('\n')
+    ]),
+    '}'
+]))


### PR DESCRIPTION
I want to make sure I plugged the right thing in here before merging.

The first box in https://shnizzedy.github.io/fcp-indi.github.com/docs/user/nuisance#configuration-without-the-gui replaces the first box in http://fcp-indi.github.io/docs/user/nuisance#configuration-without-the-gui, right?

```
{
    aCompCor: {
        summary: {
            filter: 'cosine', Principal components are estimated after using a discrete cosine filter with 128s cut-off,
                Leave filter field blank, if selected aCompcor method is 'DetrendPC'
            method: 'DetrendPC', aCompCor will extract the principal components from
                detrended tissues signal,
            components: number of components to retain,
        },
        tissues: list of tissues to extract regressors.
            Valid values are: 'WhiteMatter', 'CerebrospinalFluid',
        extraction_resolution: None | floating point value indicating isotropic
            resolution (ex. 2 for 2mm x 2mm x 2mm that data should be extracted at,
            the corresponding tissue mask will be resampled to this resolution. The
            functional data will also be resampled to this resolution, and the
            extraction will occur at this new resolution. The goal is to avoid
            contamination from undesired tissue components when extracting nuisance
            regressors,
        erode_mask: True | False, whether or not the mask should be eroded to
            further avoid a mask overlapping with a different tissue class,
        include_delayed: True | False, whether or not to include a one-frame delay regressor,
            default to False,
        include_squared: True | False, whether or not to include a squared regressor,
            default to False,
        include_delayed_squared: True | False, whether or not to include a squared one-frame
            delay regressor, default to False,
        include_backdiff: True | False, whether or not to include a one-lag difference,
            default to False,
        include_backdiff_squared: True | False, whether or not to include a squared one-frame
            delay regressor, default to False,
    },
    tCompCor: {
        summary: {
            filter: 'cosine', Principal components are estimated after using a discrete cosine filter with 128s cut-off,
                Leave filter field blank, if selected tCompcor method is 'DetrendPC'
            method: 'DetrendPC', tCompCor will extract the principal components from
                detrended tissues signal,
            components: number of components to retain,
        },
        threshold:
            floating point number = cutoff as raw variance value,
            floating point number followed by SD (ex. 1.5SD) = mean + a multiple of the SD,
            floating point number followed by PCT (ex. 2PCT) = percentile from the top (ex is top 2%),
        by_slice: True | False, whether or not the threshold criterion should be applied
            by slice or across the entire volume, makes most sense for thresholds
            using SD or PCT,
        include_delayed: True | False (same as for aCompCor),
        include_squared: True | False (same as for aCompCor),
        include_delayed_squared: True | False (same as for aCompCor),
        include_backdiff: True | False (same as for aCompCor),
        include_backdiff_squared: True | False (same as for aCompCor),
    },
    WhiteMatter: {
        summary: {
            method: 'PC', 'DetrendPC', 'Mean', 'NormMean' or 'DetrendNormMean',
            components: number of components to retain, if PC,
        },
        extraction_resolution: None | floating point value (same as for aCompCor),
        erode_mask: True | False (same as for aCompCor),
        include_delayed: True | False (same as for aCompCor),
        include_squared: True | False (same as for aCompCor),
        include_delayed_squared: True | False (same as for aCompCor),
        include_backdiff: True | False (same as for aCompCor),
        include_backdiff_squared: True | False (same as for aCompCor),
    },
    CerebrospinalFluid: {
        summary: {
            method: 'PC', 'DetrendPC', 'Mean', 'NormMean' or 'DetrendNormMean',
            components: number of components to retain, if PC,
        },
        extraction_resolution: None | floating point value (same as for aCompCor),
        erode_mask: True | False (same as for aCompCor),
        include_delayed: True | False (same as for aCompCor),
        include_squared: True | False (same as for aCompCor),
        include_delayed_squared: True | False (same as for aCompCor),
        include_backdiff: True | False (same as for aCompCor),
        include_backdiff_squared: True | False (same as for aCompCor),
    },
    GreyMatter: {
        summary: {
            method: 'PC', 'DetrendPC', 'Mean', 'NormMean' or 'DetrendNormMean',
            components: number of components to retain, if PC,
        },
        extraction_resolution: None | floating point value (same as for aCompCor),
        erode_mask: True | False (same as for aCompCor),
        include_delayed: True | False (same as for aCompCor),
        include_squared: True | False (same as for aCompCor),
        include_delayed_squared: True | False (same as for aCompCor),
        include_backdiff: True | False (same as for aCompCor),
        include_backdiff_squared: True | False (same as for aCompCor),
    },
    GlobalSignal: {
        summary: {
            method: 'PC', 'DetrendPC', 'Mean', 'NormMean' or 'DetrendNormMean',
            components: number of components to retain, if PC,
        },
        include_delayed: True | False (same as for aCompCor),
        include_squared: True | False (same as for aCompCor),
        include_delayed_squared: True | False (same as for aCompCor),
        include_backdiff: True | False (same as for aCompCor),
        include_backdiff_squared: True | False (same as for aCompCor),
    },
    Motion: None | {
        include_delayed: True | False (same as for aCompCor),
        include_squared: True | False (same as for aCompCor),
        include_delayed_squared: True | False (same as for aCompCor),
        include_backdiff: True | False (same as for aCompCor),
        include_backdiff_squared: True | False (same as for aCompCor),
    },
    Censor: {
        method: 'Kill', 'Zero', 'Interpolate', 'SpikeRegression',
        thresholds: list of dictionary, {
            type: 'FD_J', 'FD_P', 'DVARS',
            value: threshold value to be applied to metric
        },
        number_of_previous_trs_to_censor: integer, number of previous
            TRs to censor (remove or regress, if spike regression)
        number_of_subsequent_trs_to_censor: integer, number of
            subsequent TRs to censor (remove or regress, if spike
            regression)
    },
    PolyOrt: {
        degree: integer, polynomial degree up to which will be removed,
            e.g. 2 means constant + linear + quadratic, practically
            that is probably, the most that will be need especially
            if band pass filtering
    },
    Bandpass: {
        bottom_frequency: floating point value, frequency in hertz of
            the highpass part of the pass band, frequencies below this
            will be removed,
        top_frequency: floating point value, frequency in hertz of the
            lowpass part of the pass band, frequencies above this
            will be removed
    },
    Custom: [
        {
            file: file containing the regressors. It can be a CSV file,
                with one regressor per column, or a Nifti image, with
                one regressor per voxel.
            convolve: perform the convolution operation of the given
                regressor with the timeseries.
        }
    ]

}
```

from 

```
aCompCor:
    summary:
        filter: 'cosine', Principal components are estimated after using a discrete cosine filter with 128s cut-off,
            Leave filter field blank, if selected aCompcor method is 'DetrendPC'
        method: 'PC', aCompCor will always extract the principal components
            from tissues signal,
        components: number of components to retain,

    tissues: list of tissues to extract regressors.
        Valid values are: 'WhiteMatter', 'CerebrospinalFluid',

    extraction_resolution: None | floating point value indicating isotropic
        resolution (ex. 2 for 2mm x 2mm x 2mm that data should be extracted at,
        the corresponding tissue mask will be resampled to this resolution. The
        functional data will also be resampled to this resolution, and the
        extraction will occur at this new resolution. The goal is to avoid
        contamination from undesired tissue components when extracting nuisance
        regressors,

    erode_mask: True | False, whether or not the mask should be eroded to
        further avoid a mask overlapping with a different tissue class,

    include_delayed: True | False, whether or not to include a one-frame
        delay regressor, default to False,
    include_squared: True | False, whether or not to include a squared
        regressor, default to False,
    include_delayed_squared: True | False, whether or not to include a
        squared one-frame delay regressor, default to False,

tCompCor:
    summary:
        filter: 'cosine', Principal components are estimated after using a discrete cosine filter with 128s cut-off,
            Leave filter field blank, if selected aCompcor method is 'DetrendPC'
        method: 'PC', tCompCor will always extract the principal components from
            BOLD signal,
        components: number of components to retain,

    threshold:
        floating point number = cutoff as raw variance value,
        floating point number followed by SD (ex. 1.5SD) = mean + a multiple of the SD,
        floating point number followed by PCT (ex. 2PCT) = percentile from the top (ex is top 2%),

    by_slice: True | False, whether or not the threshold criterion should be applied
        by slice or across the entire volume, makes most sense for thresholds
        using SD or PCT,

    include_delayed: True | False,
    include_squared: True | False,
    include_delayed_squared: True | False,

WhiteMatter:
    summary:
        method: 'PC', 'Mean', 'NormMean' or 'DetrendNormMean',
        components: number of components to retain, if PC,

    extraction_resolution: None | floating point value (same as for aCompCor),
    erode_mask: True | False (same as for aCompCor),
    include_delayed: True | False (same as for aCompCor),
    include_squared: True | False (same as for aCompCor),
    include_delayed_squared: True | False (same as for aCompCor),

CerebrospinalFluid:
    summary:
        method: 'PC', 'Mean', 'NormMean' or 'DetrendNormMean',
        components: number of components to retain, if PC,

    extraction_resolution: None | floating point value (same as for aCompCor),
    erode_mask: True | False (same as for aCompCor),
    include_delayed: True | False (same as for aCompCor),
    include_squared: True | False (same as for aCompCor),
    include_delayed_squared: True | False (same as for aCompCor),

GreyMatter:
    summary:
        method: 'PC', 'Mean', 'NormMean' or 'DetrendNormMean',
        components: number of components to retain, if PC,

    extraction_resolution: None | floating point value (same as for aCompCor),
    erode_mask: True | False (same as for aCompCor),
    include_delayed: True | False (same as for aCompCor),
    include_squared: True | False (same as for aCompCor),
    include_delayed_squared: True | False (same as for aCompCor),

GlobalSignal:
    summary:
        method: 'PC', 'Mean', 'NormMean' or 'DetrendNormMean',
        components: number of components to retain, if PC,

    include_delayed: True | False (same as for aCompCor),
    include_squared: True | False (same as for aCompCor),
    include_delayed_squared: True | False (same as for aCompCor),

Custom: list of dictionaries, containing:
  file: file containing the regressors. It can be a CSV file,
      with one regressor per column, or a Nifti image, with
      one regressor per voxel,
  convolve: perform the convolution operation of the given
      regressor with the timeseries,

Motion: None or dictionary with values:
    include_delayed: True | False (same as for aCompCor),
    include_squared: True | False (same as for aCompCor),
    include_delayed_squared: True | False (same as for aCompCor),

Censor:
    method: 'Kill', 'Zero', 'Interpolate' or 'SpikeRegression',

    thresholds: list of dictionary, with values
        type: 'FD_J', 'FD_P', 'DVARS',
        value: threshold value to be applied to metric

    number_of_previous_trs_to_censor: integer, number of previous
        TRs to censor (remove or regress, if spike regression)

    number_of_subsequent_trs_to_censor: integer, number of
        subsequent TRs to censor (remove or regress, if spike
        regression)

PolyOrt:
    degree: integer, polynomial degree up to which will be removed,
        e.g. 2 means constant + linear + quadratic, practically
        that is probably, the most that will be need especially
        if band pass filtering

Bandpass:
    bottom_frequency: floating point value, frequency in hertz of
        the highpass part of the pass band, frequencies below this
        will be removed,

    top_frequency: floating point value, frequency in hertz of the
        lowpass part of the pass band, frequencies above this
        will be removed
```