### PR TITLE
✏️ Sort GitHub tags

### DIFF
--- a/docs/user/_sources/conf.py
+++ b/docs/user/_sources/conf.py
@@ -70,6 +70,7 @@ version = __version__
 g = Github(os.environ.get("GITHUBTOKEN"))
 gh_cpac =  g.get_user("FCP-INDI").get_repo("C-PAC")
 gh_tags =  [t.name for t in gh_cpac.get_tags()]
+gh_tags.sort(reverse=True)
 
 # Try to get release notes from GitHub
 try:


### PR DESCRIPTION
I noticed [the 1.6.1 release notes are still marked as "latest".](https://fcp-indi.github.io/docs/user/release_notes/) This PR [adds a sort before creating the "latest" doc](https://shnizzedy.github.io/fcp-indi.github.com/docs/user/release_notes/).